### PR TITLE
Add favicon and stylized BlackWallpaper header

### DIFF
--- a/app.html
+++ b/app.html
@@ -3,18 +3,19 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Black Wallpaper Generator · Solid Color | 黑色/纯色壁纸生成器</title>
+    <title>BlackWallpaper</title>
     <meta name="description" content="Create black wallpapers and solid color wallpapers in seconds (4K, 1080p, iPhone, Android). HEX/RGB/HSL input, PNG/JPEG export, one‑click color copy. 秒级生成黑色壁纸与纯色壁纸（4K、1080p、iPhone、Android），支持 HEX/RGB/HSL 与 PNG/JPEG 导出。" />
     <meta name="robots" content="index,follow" />
-    <meta property="og:title" content="Black Wallpaper Generator · Solid Color | 黑色/纯色壁纸生成器" />
-    <meta property="og:description" content="Create black wallpapers (4K, iPhone, Android) and solid color backgrounds. HEX/RGB/HSL, presets, PNG/JPEG export." />
+    <meta property="og:title" content="BlackWallpaper" />
+    <meta property="og:description" content="Create black wallpapers and solid color backgrounds. HEX/RGB/HSL, presets, PNG/JPEG export." />
     <meta property="og:type" content="website" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <div id="app">
       <header class="panel__header">
-        <h1 data-i18n="appTitle">纯色壁纸生成器</h1>
+        <h1 class="logo">Black<span class="accent">Wallpaper</span></h1>
         <div class="header__actions">
           <button id="langToggleBtn" title="Language / 语言">EN</button>
           <button id="fullscreenBtn" data-i18n="btnFullscreen" title="全屏预览">全屏预览</button>

--- a/black-wallpaper/1080p-1920x1080/index.html
+++ b/black-wallpaper/1080p-1920x1080/index.html
@@ -2,6 +2,6 @@
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>1080p Black Wallpaper (1920×1080) — Generator</title>
 <meta name="description" content="Create 1080p black wallpapers (1920×1080). True black #000000. PNG/JPEG export."/>
-<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/1080p-1920x1080/"/>
+<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/1080p-1920x1080/"/><link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 <style>body{font-family:-apple-system,BlinkMacSystemFont,system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:0;padding:28px;color:#111;background:#fafafa}.container{max-width:880px;margin:0 auto}.card{background:#fff;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:18px;box-shadow:0 8px 28px rgba(0,0,0,.08)}</style></head>
 <body><div class="container"><div class="card"><h1>1080p Black Wallpaper — 1920×1080</h1><p>Generate #000000 black wallpaper at 1920×1080 (Full HD).</p><p><a href="../../app.html?color=%23000000&w=1920&h=1080&format=png">Create this size online →</a></p></div></div></body></html>

--- a/black-wallpaper/1440p-2560x1440/index.html
+++ b/black-wallpaper/1440p-2560x1440/index.html
@@ -2,6 +2,6 @@
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>1440p Black Wallpaper (2560×1440) — Generator</title>
 <meta name="description" content="Create 1440p black wallpapers (2560×1440). True black #000000. PNG/JPEG export."/>
-<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/1440p-2560x1440/"/>
+<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/1440p-2560x1440/"/><link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 <style>body{font-family:-apple-system,BlinkMacSystemFont,system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:0;padding:28px;color:#111;background:#fafafa}.container{max-width:880px;margin:0 auto}.card{background:#fff;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:18px;box-shadow:0 8px 28px rgba(0,0,0,.08)}</style></head>
 <body><div class="container"><div class="card"><h1>1440p Black Wallpaper — 2560×1440</h1><p>Generate #000000 black wallpaper at 2560×1440 (QHD).</p><p><a href="../../app.html?color=%23000000&w=2560&h=1440&format=png">Create this size online →</a></p></div></div></body></html>

--- a/black-wallpaper/4k-3840x2160/index.html
+++ b/black-wallpaper/4k-3840x2160/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>4K Black Wallpaper (3840×2160) — Generator</title>
   <meta name="description" content="Download or create 4K black wallpaper (3840×2160). True black #000000, ideal for OLED/AMOLED and desktop. PNG/JPEG export." />
-  <link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/4k-3840x2160/" />
+  <link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/4k-3840x2160/" /><link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
   <meta property="og:title" content="4K Black Wallpaper (3840×2160) — Generator" />
   <meta property="og:description" content="Create and export 4K black wallpapers. True black #000000, PNG/JPEG." />
   <style>body{font-family:-apple-system,BlinkMacSystemFont,system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:0;padding:28px;color:#111;background:#fafafa}.container{max-width:880px;margin:0 auto}.card{background:#fff;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:18px;box-shadow:0 8px 28px rgba(0,0,0,.08)}</style>

--- a/black-wallpaper/5k-5120x2880/index.html
+++ b/black-wallpaper/5k-5120x2880/index.html
@@ -2,6 +2,6 @@
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>5K Black Wallpaper (5120×2880)</title>
 <meta name="description" content="Create 5K black wallpaper (5120×2880). True black #000000. PNG/JPEG export."/>
-<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/5k-5120x2880/"/>
+<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/5k-5120x2880/"/><link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 <style>body{font-family:-apple-system,BlinkMacSystemFont,system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:0;padding:28px;color:#111;background:#fafafa}.container{max-width:880px;margin:0 auto}.card{background:#fff;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:18px;box-shadow:0 8px 28px rgba(0,0,0,.08)}</style></head>
 <body><div class="container"><div class="card"><h1>5K Black Wallpaper — 5120×2880</h1><p>Generate #000000 black wallpaper for 5K displays.</p><p><a href="../../app.html?color=%23000000&w=5120&h=2880&format=png">Create this size online →</a></p></div></div></body></html>

--- a/black-wallpaper/android-1440x3120/index.html
+++ b/black-wallpaper/android-1440x3120/index.html
@@ -2,6 +2,6 @@
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Android Black Wallpaper (1440×3120)</title>
 <meta name="description" content="Create Android black wallpaper (1440×3120). True black #000000. PNG/JPEG export."/>
-<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/android-1440x3120/"/>
+<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/android-1440x3120/"/><link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 <style>body{font-family:-apple-system,BlinkMacSystemFont,system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:0;padding:28px;color:#111;background:#fafafa}.container{max-width:880px;margin:0 auto}.card{background:#fff;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:18px;box-shadow:0 8px 28px rgba(0,0,0,.08)}</style></head>
 <body><div class="container"><div class="card"><h1>Android Black Wallpaper — 1440×3120</h1><p>Generate #000000 black wallpaper for Android devices.</p><p><a href="../../app.html?color=%23000000&w=1440&h=3120&format=png">Create this size online →</a></p></div></div></body></html>

--- a/black-wallpaper/ipad-pro-2732x2048/index.html
+++ b/black-wallpaper/ipad-pro-2732x2048/index.html
@@ -2,6 +2,6 @@
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>iPad Pro Black Wallpaper (2732×2048)</title>
 <meta name="description" content="Create iPad Pro black wallpaper (2732×2048). True black #000000. PNG/JPEG export."/>
-<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/ipad-pro-2732x2048/"/>
+<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/ipad-pro-2732x2048/"/><link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 <style>body{font-family:-apple-system,BlinkMacSystemFont,system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:0;padding:28px;color:#111;background:#fafafa}.container{max-width:880px;margin:0 auto}.card{background:#fff;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:18px;box-shadow:0 8px 28px rgba(0,0,0,.08)}</style></head>
 <body><div class="container"><div class="card"><h1>iPad Pro Black Wallpaper — 2732×2048</h1><p>Generate #000000 black wallpaper for iPad Pro.</p><p><a href="../../app.html?color=%23000000&w=2732&h=2048&format=png">Create this size online →</a></p></div></div></body></html>

--- a/black-wallpaper/iphone-15-pro-1179x2556/index.html
+++ b/black-wallpaper/iphone-15-pro-1179x2556/index.html
@@ -2,6 +2,6 @@
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>iPhone 15 Pro Black Wallpaper (1179×2556)</title>
 <meta name="description" content="Create iPhone 15 Pro black wallpaper (1179×2556). True black #000000. PNG/JPEG export."/>
-<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/iphone-15-pro-1179x2556/"/>
+<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/iphone-15-pro-1179x2556/"/><link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 <style>body{font-family:-apple-system,BlinkMacSystemFont,system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:0;padding:28px;color:#111;background:#fafafa}.container{max-width:880px;margin:0 auto}.card{background:#fff;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:18px;box-shadow:0 8px 28px rgba(0,0,0,.08)}</style></head>
 <body><div class="container"><div class="card"><h1>iPhone 15 Pro Black Wallpaper — 1179×2556</h1><p>Generate #000000 black wallpaper for iPhone 15 Pro.</p><p><a href="../../app.html?color=%23000000&w=1179&h=2556&format=png">Create this size online →</a></p></div></div></body></html>

--- a/black-wallpaper/iphone-se-750x1334/index.html
+++ b/black-wallpaper/iphone-se-750x1334/index.html
@@ -2,6 +2,6 @@
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>iPhone SE Black Wallpaper (750×1334)</title>
 <meta name="description" content="Create iPhone SE black wallpaper (750×1334). True black #000000. PNG/JPEG export."/>
-<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/iphone-se-750x1334/"/>
+<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/iphone-se-750x1334/"/><link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 <style>body{font-family:-apple-system,BlinkMacSystemFont,system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:0;padding:28px;color:#111;background:#fafafa}.container{max-width:880px;margin:0 auto}.card{background:#fff;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:18px;box-shadow:0 8px 28px rgba(0,0,0,.08)}</style></head>
 <body><div class="container"><div class="card"><h1>iPhone SE Black Wallpaper — 750×1334</h1><p>Generate #000000 black wallpaper for iPhone SE.</p><p><a href="../../app.html?color=%23000000&w=750&h=1334&format=png">Create this size online →</a></p></div></div></body></html>

--- a/black-wallpaper/macbook-pro-2880x1800/index.html
+++ b/black-wallpaper/macbook-pro-2880x1800/index.html
@@ -2,6 +2,6 @@
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>MacBook Pro Black Wallpaper (2880×1800)</title>
 <meta name="description" content="Create MacBook Pro black wallpaper (2880×1800). True black #000000. PNG/JPEG export."/>
-<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/macbook-pro-2880x1800/"/>
+<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/macbook-pro-2880x1800/"/><link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 <style>body{font-family:-apple-system,BlinkMacSystemFont,system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:0;padding:28px;color:#111;background:#fafafa}.container{max-width:880px;margin:0 auto}.card{background:#fff;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:18px;box-shadow:0 8px 28px rgba(0,0,0,.08)}</style></head>
 <body><div class="container"><div class="card"><h1>MacBook Pro Black Wallpaper — 2880×1800</h1><p>Generate #000000 black wallpaper for MacBook Pro.</p><p><a href="../../app.html?color=%23000000&w=2880&h=1800&format=png">Create this size online →</a></p></div></div></body></html>

--- a/black-wallpaper/ultrawide-3440x1440/index.html
+++ b/black-wallpaper/ultrawide-3440x1440/index.html
@@ -2,6 +2,6 @@
 <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Ultrawide Black Wallpaper (3440×1440) — Generator</title>
 <meta name="description" content="Create ultrawide black wallpapers (3440×1440). True black #000000. PNG/JPEG export."/>
-<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/ultrawide-3440x1440/"/>
+<link rel="canonical" href="https://wallpaperonline.net/black-wallpaper/ultrawide-3440x1440/"/><link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 <style>body{font-family:-apple-system,BlinkMacSystemFont,system-ui,Segoe UI,Roboto,Helvetica,Arial;margin:0;padding:28px;color:#111;background:#fafafa}.container{max-width:880px;margin:0 auto}.card{background:#fff;border:1px solid rgba(0,0,0,.06);border-radius:16px;padding:18px;box-shadow:0 8px 28px rgba(0,0,0,.08)}</style></head>
 <body><div class="container"><div class="card"><h1>Ultrawide Black Wallpaper — 3440×1440</h1><p>Generate #000000 black wallpaper for ultrawide monitors.</p><p><a href="../../app.html?color=%23000000&w=3440&h=1440&format=png">Create this size online →</a></p></div></div></body></html>

--- a/en/index.html
+++ b/en/index.html
@@ -3,13 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Black Wallpaper Generator · Solid Color</title>
+    <title>BlackWallpaper</title>
     <meta name="description" content="Create black wallpapers and solid color wallpapers fast (4K, 1080p, iPhone, Android). HEX/RGB/HSL, PNG/JPEG export." />
     <meta name="robots" content="index,follow" />
     <link rel="canonical" href="https://wallpaperonline.net/en/" />
     <link rel="alternate" href="https://wallpaperonline.net/landing.html" hreflang="zh-CN" />
     <link rel="alternate" href="https://wallpaperonline.net/en/" hreflang="en" />
     <link rel="alternate" href="https://wallpaperonline.net/landing.html" hreflang="x-default" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <meta property="og:title" content="Black Wallpaper Generator · Solid Color" />
     <meta property="og:description" content="Create, preview and download black and solid color wallpapers. HEX/RGB/HSL, presets, PNG/JPEG export." />
     <meta property="og:type" content="website" />
@@ -20,6 +21,7 @@
       .container { max-width: 1080px; margin: 0 auto; padding: 28px 20px 48px; }
       header { display:flex; align-items:flex-start; justify-content:space-between; gap: 16px; }
       header h1 { margin: 0 0 8px 0; font-size: 28px; font-weight: 800; }
+      header h1 .accent { color: var(--link); }
       header p { margin: 0; color: var(--muted); }
       .grid { display:grid; grid-template-columns: 1fr; gap:20px; margin-top:22px; }
       .card { background:#fff; border:1px solid rgba(0,0,0,.06); border-radius: 16px; padding: 18px; box-shadow: 0 8px 28px rgba(0,0,0,.08); }
@@ -35,7 +37,7 @@
     <div class="container">
       <header>
         <div>
-          <h1>Black Wallpaper Generator</h1>
+          <h1 class="logo">Black<span class="accent">Wallpaper</span></h1>
           <p>Generate true black (#000000) and solid color wallpapers. Popular sizes: 4K, 1440p, 1080p, iPhone, Android.</p>
         </div>
       </header>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#000"/>
+  <text x="50" y="65" font-size="60" fill="#0A84FF" text-anchor="middle" font-family="Arial, sans-serif">B</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Black Wallpaper Generator · Solid Color | 黑色/纯色壁纸生成器</title>
+    <title>BlackWallpaper</title>
     <meta name="description" content="Create black wallpapers and solid color wallpapers fast (4K, 1080p, iPhone, Android). HEX/RGB/HSL, PNG/JPEG export. 生成黑色壁纸与纯色壁纸（4K、1080p、iPhone、Android），支持 HEX/RGB/HSL 与 PNG/JPEG 导出。" />
     <meta name="keywords" content="black wallpaper, 4k black wallpaper, iphone black wallpaper, android black wallpaper, desktop black background, minimalist black wallpaper, amoled black, true black wallpaper, solid black wallpaper, black background image, wallpaper generator, solid color wallpaper, color background, 纯黑 壁纸, 黑色 壁纸, 4K 黑色 壁纸, iPhone 黑色 壁纸, Android 黑色 壁纸, 桌面 黑色 壁纸, AMOLED 省电 壁纸, 纯色 壁纸, 壁纸 生成器" />
     <meta name="robots" content="index,follow" />
@@ -11,6 +11,7 @@
     <link rel="alternate" href="https://wallpaperonline.net/" hreflang="zh-CN" />
     <link rel="alternate" href="https://wallpaperonline.net/en/" hreflang="en" />
     <link rel="alternate" href="https://wallpaperonline.net/" hreflang="x-default" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <meta property="og:title" content="Solid Color Wallpaper Generator | 纯色壁纸生成器" />
     <meta property="og:description" content="Create black wallpapers (4K, iPhone, Android) and solid color backgrounds. HEX/RGB/HSL, presets, PNG/JPEG export." />
     <meta property="og:type" content="website" />
@@ -25,6 +26,7 @@
       .container { max-width: 1080px; margin: 0 auto; padding: 28px 20px 48px; }
       header { display:flex; align-items:flex-start; justify-content:space-between; gap: 16px; }
       header h1 { margin: 0 0 8px 0; font-size: 28px; font-weight: 800; }
+      header h1 .accent { color: var(--link); }
       header p { margin: 0; color: var(--muted); }
       .header-actions { display:flex; align-items:center; gap: 8px; }
       .lang-toggle { height: 36px; min-width: 44px; padding: 0 12px; border-radius: 10px; border:1px solid rgba(0,0,0,.08); background:#fff; cursor:pointer; }
@@ -108,7 +110,7 @@
     <div class="container">
       <header>
         <div>
-          <h1><span data-i18n="title">纯色壁纸生成器</span> <span style="font-weight:600; color:var(--muted); font-size:20px;" data-i18n="titleEn">Solid Color Wallpaper</span></h1>
+          <h1 class="logo">Black<span class="accent">Wallpaper</span></h1>
           <p data-i18n="subtitle">高性能、纯前端、无依赖，支持 HEX/RGB/HSL、常用分辨率预设、PNG/JPEG 导出与一键复制。</p>
         </div>
         <div class="header-actions">
@@ -265,7 +267,7 @@
           if(btn){ btn.textContent = lang==='zh-CN' ? 'EN' : '中'; btn.title='Language / 语言'; }
           const frame=document.getElementById('appFrame');
           if(frame){ frame.title=dict.frameTitle; }
-          document.title = (lang==='zh-CN') ? '黑色壁纸生成器 | 纯色壁纸生成器' : 'Black Wallpaper Generator | Solid Color Wallpaper';
+          document.title = 'BlackWallpaper';
           document.documentElement.setAttribute('lang', lang==='zh-CN' ? 'zh-CN' : 'en');
           // share intents
           const pageURL = window.location.origin + window.location.pathname;

--- a/landing.html
+++ b/landing.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Black Wallpaper Generator · Solid Color | 黑色/纯色壁纸生成器</title>
+    <title>BlackWallpaper</title>
     <meta name="description" content="Create black wallpapers and solid color wallpapers fast (4K, 1080p, iPhone, Android). HEX/RGB/HSL, PNG/JPEG export. 生成黑色壁纸与纯色壁纸（4K、1080p、iPhone、Android），支持 HEX/RGB/HSL 与 PNG/JPEG 导出。" />
     <meta name="keywords" content="black wallpaper, 4k black wallpaper, iphone black wallpaper, android black wallpaper, desktop black background, minimalist black wallpaper, amoled black, true black wallpaper, solid black wallpaper, black background image, wallpaper generator, solid color wallpaper, color background, 纯黑 壁纸, 黑色 壁纸, 4K 黑色 壁纸, iPhone 黑色 壁纸, Android 黑色 壁纸, 桌面 黑色 壁纸, AMOLED 省电 壁纸, 纯色 壁纸, 壁纸 生成器" />
     <meta name="robots" content="index,follow" />
@@ -11,6 +11,7 @@
     <link rel="alternate" href="https://wallpaperonline.net/" hreflang="zh-CN" />
     <link rel="alternate" href="https://wallpaperonline.net/en/" hreflang="en" />
     <link rel="alternate" href="https://wallpaperonline.net/" hreflang="x-default" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <meta property="og:title" content="Solid Color Wallpaper Generator | 纯色壁纸生成器" />
     <meta property="og:description" content="Create black wallpapers (4K, iPhone, Android) and solid color backgrounds. HEX/RGB/HSL, presets, PNG/JPEG export." />
     <meta property="og:type" content="website" />
@@ -25,6 +26,7 @@
       .container { max-width: 1080px; margin: 0 auto; padding: 28px 20px 48px; }
       header { display:flex; align-items:flex-start; justify-content:space-between; gap: 16px; }
       header h1 { margin: 0 0 8px 0; font-size: 28px; font-weight: 800; }
+      header h1 .accent { color: var(--link); }
       header p { margin: 0; color: var(--muted); }
       .header-actions { display:flex; align-items:center; gap: 8px; }
       .lang-toggle { height: 36px; min-width: 44px; padding: 0 12px; border-radius: 10px; border:1px solid rgba(0,0,0,.08); background:#fff; cursor:pointer; }
@@ -108,7 +110,7 @@
     <div class="container">
       <header>
         <div>
-          <h1><span data-i18n="title">纯色壁纸生成器</span> <span style="font-weight:600; color:var(--muted); font-size:20px;" data-i18n="titleEn">Solid Color Wallpaper</span></h1>
+          <h1 class="logo">Black<span class="accent">Wallpaper</span></h1>
           <p data-i18n="subtitle">高性能、纯前端、无依赖，支持 HEX/RGB/HSL、常用分辨率预设、PNG/JPEG 导出与一键复制。</p>
         </div>
         <div class="header-actions">
@@ -265,7 +267,7 @@
           if(btn){ btn.textContent = lang==='zh-CN' ? 'EN' : '中'; btn.title='Language / 语言'; }
           const frame=document.getElementById('appFrame');
           if(frame){ frame.title=dict.frameTitle; }
-          document.title = (lang==='zh-CN') ? '黑色壁纸生成器 | 纯色壁纸生成器' : 'Black Wallpaper Generator | Solid Color Wallpaper';
+          document.title = 'BlackWallpaper';
           document.documentElement.setAttribute('lang', lang==='zh-CN' ? 'zh-CN' : 'en');
           // share intents
           const pageURL = window.location.origin + window.location.pathname;

--- a/styles.css
+++ b/styles.css
@@ -56,6 +56,10 @@ body {
   font-weight: 700;
 }
 
+.logo .accent {
+  color: var(--primary);
+}
+
 .header__actions button {
   margin-left: 8px;
 }


### PR DESCRIPTION
## Summary
- Add SVG favicon and reference it across pages
- Replace headings with brand name “BlackWallpaper” and blue accent on “Wallpaper”
- Support accent styling in app styles

## Testing
- `npm test` (fails: Could not find package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bd6badf630832da043c5968c9b37ad